### PR TITLE
Fix issue #7: Ctrl-D hell

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -138,8 +138,7 @@ class ip_file : public device {
 void ip_file::file_input() {
   char str[30];
 
-  while (1) {
-    cin.getline(str, 30, '\n');
+  while (cin.getline(str, 30, '\n')) {
 
     if (timeObj.get_enable_status()) print_time();
 


### PR DESCRIPTION
Pressing Ctrl-D now simply exits the console.