### PR TITLE
Fix #35: Backspace goes beyond prompt

### DIFF
--- a/welcome2.cpp
+++ b/welcome2.cpp
@@ -48,6 +48,7 @@ void trans_rec_win(){
 			col = 0;
 			move(47, 20);
 		} else if (ch == KEY_BACKSPACE) {
+			if (!col) continue;
 			line.pop_back();
 			move(47, 20); clrtoeol();
 			mvprintw(47,20,line.c_str());


### PR DESCRIPTION
This fixes the issue that backspacing a line uptil the first character didn't stop and continued to `pop_back()` from `line` buffer which eventually caused a segfault.