### PR TITLE
Windowfy console screen

### DIFF
--- a/Final_Project.cpp
+++ b/Final_Project.cpp
@@ -229,13 +229,6 @@ void menu_call() {
   WINDOW *my_menu_win, *my_menu_win1, *my_menu_win2, *my_menu_win3,
       *my_menu_win4, *my_menu_win5, *my_menu_win6;
 
-  /* Initialize curses */
-  initscr();
-  start_color();
-  cbreak();
-  noecho();
-  keypad(stdscr, TRUE);
-
   memory.colourfulObj.change_clor_scheme(
       memory.colourfulObj.return_colourStatus());
   init_pair(2, COLOR_GREEN, COLOR_BLACK);
@@ -281,15 +274,14 @@ void menu_call() {
           unpost_menu(my_menu);
           for (int i = 0; i < 9; ++i) free_item(my_item[i]);
           free_menu(my_menu);
-          endwin();
-          if (flag) system("clear");
+          werase(my_menu_win);
+          wrefresh(my_menu_win);
           return;
         } else if (!strcmp(item_name(current_item(my_menu)), "EXIT Console")) {
           unpost_menu(my_menu);
           for (int i = 0; i < 9; ++i) free_item(my_item[i]);
           free_menu(my_menu);
           endwin();
-          system("clear");
           exit(EXIT_SUCCESS);
         } else if (!strcmp(item_name(current_item(my_menu)), "Clear Screen")) {
           mvprintw(20, 0, "Item selected is : %s",

--- a/welcome2.cpp
+++ b/welcome2.cpp
@@ -1,5 +1,4 @@
 #include <ncurses.h>
-
 #include <cstring>
 #include <iostream>
 #include <string>
@@ -13,6 +12,9 @@ void trans_rec_win();
 void clear_lines();
 int truncater(string&, int);
 void menu_call();
+
+WINDOW* win;
+
 /********************-CLASS-**********************/
 
 class conversion {
@@ -78,32 +80,36 @@ void displayer(void) {
   noecho();
   keypad(stdscr, TRUE);
 
+  win = newwin(46, 200, 1, 1);
   init_pair(1, COLOR_YELLOW, COLOR_BLACK);
-  for (int i = 2; i <= 45; i++) mvprintw(i, 95, "|");
-  attron(COLOR_PAIR(1));
-  attron(A_BOLD);
-  attron(A_STANDOUT);
-  mvprintw(1, 45, "TX");
-  mvprintw(1, 140, "RX");
-  attroff(A_STANDOUT);
-  attroff(COLOR_PAIR(1));
+  mvwvline(win, 1, 95, '|', 44);
+  wattron(win, COLOR_PAIR(1));
+  wattron(win, A_BOLD);
+  wattron(win, A_STANDOUT);
+  mvwprintw(win, 0, 45, "TX");
+  mvwprintw(win, 0, 140, "RX");
+  wattroff(win, A_STANDOUT);
+  wattroff(win, COLOR_PAIR(1));
   mvprintw(47, 5, "Enter here -->");
-  attroff(A_BOLD);
+  wattroff(win, A_BOLD);
+  mvwhline(win, 45, 1, '-', 180);
 
   refresh();
-  for (int j = 2; j <= 180; j++) mvprintw(45, j, "_");
+  wrefresh(win);
   move(47, 20);
 }
 
 void input_display() {
   string line;
-  int i = 4, col = 0;
+  int i = 2, col = 0;
   int ch;
   while (ch = wgetch(stdscr)) {
-    if ((ch == '\n') && (line != "__MENU")) {
-      if (line.size() < 90)
-        mvprintw(i, 2, line.c_str());
-      else
+    if (ch == '\n') {
+      if (line.size() < 90) {
+        mvwprintw(win, i, 0, line.c_str());
+        wrefresh(win);
+        refresh();
+      } else
         i = truncater(line, i);
       i++;
       clear_lines();
@@ -116,18 +122,20 @@ void input_display() {
       clear_lines();
       mvprintw(47, 20, line.c_str());
       move(47, 20 + --col);
+    } else if (ch == KEY_F(1)) {
+        int x, y;
+        getyx(stdscr, y, x);
+        menu_call();
+        redrawwin(win);
+        wrefresh(win);
+        move(y, x);
     } else {
       line.push_back(ch);
       mvprintw(47, 20, line.c_str());
       move(47, 20 + ++col);
     }
-    if (line == "__MENU") {
-      menu_call();
-    } else if (line == "quit")
-      break;
   }
 
-  getch();
   endwin();
 }
 


### PR DESCRIPTION
Changes:
- Typing `__MENU' to call for menu is deprecated, press F1 to perform
  the same action.
- Erase menu when it exits.
- Windowfy the console screen such that it can be redrawn once menu
  exits.
- Replace for looped line rendering to pretty ncurses functions namely
  mvwvline() and mvwhline().